### PR TITLE
added data.stackexchange.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,10 @@ Other amazingly awesome lists can be found in the
 `awesome-awesomeness <https://github.com/bayandin/awesome-awesomeness>`_ and
 `another awesome <https://github.com/sindresorhus/awesome>`_ list.
 
+APIs of Web-Sites for Data Retrieval
+-------
+* data.stackexchange.com: http://data.stackexchange.com/
+
 Climate/Weather
 -------
 


### PR DESCRIPTION
Didn't find a category already present where data.SE.com would fit into. Basically it belongs to a special breed of data sources providing web-site usage data through an API. In this case the API is accessible through T-SQL and provides interesting data about technology.
