### PR TITLE
Add Libraries.io Open Source Repository and Dependency Metadata release to Software category

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -537,6 +537,7 @@ Software
 --------
 
 * `FLOSSmole data about free, libre, and open source software development <http://flossdata.syr.edu/data/>`_
+* `Libraries.io Open Source Repository and Dependency Metadata <https://zenodo.org/record/808273>`_
 
 Sports
 ------


### PR DESCRIPTION
URL: https://zenodo.org/record/808273 
License: CC-BY-SA

More details in our release blogpost: https://medium.com/@BenJam/libraries-io-releases-data-on-over-25m-software-repositories-ab1db665826e