### PR TITLE
Adding an "Education" dataset: Longitudinal study of salaries by college type, region, and major

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,9 @@ Education
 
 * `College Scorecard Data <https://collegescorecard.ed.gov/data/>`_
 * `Student Data from Free Code Camp <http://academictorrents.com/details/030b10dad0846b5aecc3905692890fb02404adbf>`_
-
+* `WSJ - Longitudinal Study - Salaries by Type of College <http://online.wsj.com/public/resources/documents/info-Salaries_for_Colleges_by_Type-sort.html>`_
+* `WSJ - Longitudinal Study - Salaries for Colleges by Major <http://online.wsj.com/public/resources/documents/info-Degrees_that_Pay_you_Back-sort.html>`_
+* `WSJ - Longitudinal Study - Salaries for Colleges by Region <http://online.wsj.com/public/resources/documents/info-Salaries_for_Colleges_by_Region-sort.html>`_
 
 Energy
 ------


### PR DESCRIPTION
The data include information on starting and midcareer salaries for many combinations of college type, geographic region, and undergraduate major. It is based on a survey of 1.2 million bachelor's degree graduates. The results have been reported in The Wall Street Journal, see <https://www.wsj.com/articles/SB121746658635199271>.

Very nice for practicing basic data manipulation and analysis techniques.