### PR TITLE
updated link for Ghent, Belgium

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -499,7 +499,7 @@ Government
         
 * |OK_ICON| `Germany <https://www-genesis.destatis.de/genesis/online>`_
         
-* |FIXME_ICON| `Ghent, Belgium <https://data.stad.gent/datasets>`_
+* |FIXME_ICON| `Ghent, Belgium <https://data.stad.gent/data>`_
         
 * |FIXME_ICON| `Glasgow, Scotland, UK <https://data.glasgow.gov.uk/>`_
         


### PR DESCRIPTION
pointed to https://data.stad.gent/datasets instead of https://data.stad.gent/data