### PR TITLE
NIH Microarray data link made clickable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Biology
         
 * |OK_ICON| `NCI Genomic Data Commons <https://gdc.cancer.gov/access-data/gdc-data-portal>`_
         
-* |OK_ICON| `NIH Microarray data <ftp://ftp.ncbi.nih.gov/pub/geo/DATA/supplementary/series/GSE6532/>`_
+* |OK_ICON| `NIH Microarray data <https://ftp.ncbi.nih.gov/pub/geo/DATA/supplementary/series/GSE6532/>`_
         
 * |OK_ICON| `OpenSNP genotypes data <https://opensnp.org/>`_
         


### PR DESCRIPTION
**The problem.** Under the `Biology` section, the link for NIH Microarray data is not clickable.

**Reason.** Apparently, GitHub won't make text a link if the protocol used is ftp. (Your link was ftp://ftp.ncbi.nih.gov/pub/geo/DATA/supplementary/series/GSE6532/).

**Change I made.** Changed the protocol from ftp to https, keeping the rest of the link the same. Now, the link is clickable in the README file, and opens just fine on clicking, thereby fixing the problem.