### PR TITLE
Update CVonline Image Databases link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1552,5 +1552,5 @@ Complementary Collections
 
 * CV Papers: `CV Datasets on the web <http://www.cvpapers.com/datasets.html/>`_
 
-* CVonline: `Image Databases <http://homepages.inf.ed.ac.uk/rbf/CVonline/Imagedbase.htm/>`_
+* CVonline: `Image Databases <http://homepages.inf.ed.ac.uk/rbf/CVonline/Imagedbase.htm>`_
 


### PR DESCRIPTION
CVonline image databases link in the repo is not working I made a correcting to the right link