### PR TITLE
Add dna-claude-analysis to Biology section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,8 @@ Biology
         
 * |OK_ICON| `CytoImageNet - A large-scale dataset of microscopy images. Contains 890,737 total grayscale [...] <https://www.kaggle.com/stanleyhua/cytoimagenet>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/CytoImageNet.yml>`_]
         
+        
+* |OK_ICON| `DNA Claude Analysis - Personal genome analysis toolkit with Python scripts analyzing raw DNA data across 17 categories (ancestry, health risks, nutrition, sports, pharmacogenomics, and more) with terminal-style HTML visualization. <https://github.com/shmlkv/dna-claude-analysis>`_
 * |OK_ICON| `EBI ArrayExpress - ArrayExpress Archive of Functional Genomics Data stores data from high- [...] <http://www.ebi.ac.uk/arrayexpress/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/EBI-ArrayExpress.yml>`_]
         
 * |OK_ICON| `EBI Protein Data Bank in Europe - The Electron Microscopy Data Bank (EMDB) is a public [...] <https://www.ebi.ac.uk/emdb/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/EBI-Protein-Data-Bank-in-Europe.yml>`_]


### PR DESCRIPTION
## Summary

Adds [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the **Biology** section.

**What it is:** Personal genome analysis toolkit with Python scripts that analyze raw DNA data across 17 categories — ancestry, health risks, nutrition, sports/fitness, pharmacogenomics, carrier status, longevity, sleep, immunity, pain sensitivity, detoxification, skin, vision/hearing, physical traits, psychology, cognitive, and more — and generate a terminal-style single-page HTML visualization from the results.

**Why it fits:** The project works directly with raw DNA data files (e.g. from consumer genetic tests), provides structured genomic analysis pipelines, and produces human-readable reports from personal genome data. It complements existing entries like OpenSNP genotypes data and the Human Genome Diversity Project.

**Entry added (alphabetically after CytoImageNet):**
```
* |OK_ICON| `DNA Claude Analysis - Personal genome analysis toolkit with Python scripts analyzing raw
  DNA data across 17 categories (ancestry, health risks, nutrition, sports, pharmacogenomics, and more)
  with terminal-style HTML visualization. <https://github.com/shmlkv/dna-claude-analysis>`_
```