### PR TITLE
Add ProofBets crypto casino data API to Finance section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -527,6 +527,7 @@ Finance
 * |FIXME_ICON| `SEC EDGAR - EDGAR, the Electronic Data Gathering, Analysis, and Retrieval system, is the [...] <https://www.sec.gov/edgar/about>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Finance/SEC-EDGAR.yml>`_]
         
 * |OK_ICON| `St Louis Federal <https://research.stlouisfed.org/fred2/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Finance/St-Louis-Federal.yml>`_]
+* |OK_ICON| `ProofBets API - Free REST API for crypto casino data: 50+ casinos, bonus codes, withdrawal speeds, P2P prediction market platforms (Polymarket, Kalshi, Azuro), and on-chain verification. 16 endpoints, OpenAPI 3.1 spec. <https://proofbets.com/developers/>`_
         
 * |FIXME_ICON| `Yahoo Finance <http://finance.yahoo.com/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Finance/Yahoo-Finance.yml>`_]
     


### PR DESCRIPTION
ProofBets (https://proofbets.com) provides a free public REST API for crypto casino and prediction market data.

- 16 endpoints: casinos, bonuses, P2P platforms (Polymarket, Kalshi, Azuro), World Cup odds, EV calculator
- On-chain wallet verification via Etherscan
- Live TVL tracking via DeFi Llama
- OpenAPI 3.1 spec: https://proofbets.com/openapi.yaml
- Free tier: 20 req/min (no key required)

Added to Finance section, alphabetically before Yahoo Finance.