### PR TITLE
Add ProofBets API — Crypto casino and prediction market dataset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -522,6 +522,8 @@ Finance
         
 * |FIXME_ICON| `OSU Financial data <http://fisher.osu.edu/fin/fdf/osudata.htm>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Finance/OSU-Financial-data.yml>`_]
         
+* |OK_ICON| `ProofBets API - Free API for crypto casino data: 50+ casinos, verified bonus codes, withdrawal speeds, prediction market fees, World Cup odds. OpenAPI 3.1. <https://proofbets.com/developers/>`_
+        
 * |OK_ICON| `Quandl <https://www.quandl.com/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Finance/Quandl.yml>`_]
         
 * |FIXME_ICON| `SEC EDGAR - EDGAR, the Electronic Data Gathering, Analysis, and Retrieval system, is the [...] <https://www.sec.gov/edgar/about>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Finance/SEC-EDGAR.yml>`_]


### PR DESCRIPTION
A free, structured dataset of crypto casino and prediction market data via a 16-endpoint REST API. Data includes 50+ casino reviews, daily-monitored bonus codes, withdrawal speed benchmarks, prediction market fees across 7 platforms, and World Cup 2026 odds. OpenAPI 3.1 spec at proofbets.com/openapi.yaml. Free tier: 20 req/min.

Checklist:
- [x] Alphabetical order
- [x] Follows contribution guidelines
- [x] Link is working