### PR TITLE
Add Property Comps -- global property transaction data (11 markets)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -437,6 +437,8 @@ Economics
 * |OK_ICON| `World KLEMS - Analytical KLEMS-type data sets for a broad set of countries around the world. [...] <https://www.worldklems.net/wkanalytical>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/World KLEMS.yml>`_]
         
 * |OK_ICON| `Prop-Metrics — U.S. ZIP-Code-Level Real Estate Analytics Dataset - A comprehensive dataset [...] <https://www.prop-metrics.com>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/prop-metrics-real-estate-data.yml>`_]
+        
+* |OK_ICON| `Property Comps — Comparable Property Sales Across 11 Global Markets - Free API providing 44M+ property transactions from government registries (HM Land Registry, DVF, HDB, NYC DOF) across UK, France, Singapore, NYC, Chicago, Dubai, and 5 more markets. Search by location, filter by property type, with Swagger docs. <https://api.nwc-advisory.com/docs>`_
     
 Education
 ---------


### PR DESCRIPTION
Adding **Property Comps** to the Economics section.

**What it is:** Free REST API providing comparable property transaction data from official government registries across 11 global markets:

| Market | Source | Transactions |
|--------|--------|-------------|
| UK (England & Wales) | HM Land Registry Price Paid | 31M+ |
| France | DVF (Demandes de Valeurs Foncieres) | 8.3M+ |
| Singapore | HDB Resale Transactions | 973K+ |
| NYC | Dept. of Finance Rolling Sales | 51K+ |
| Chicago | Cook County Assessor | 2.1M+ |
| Dubai | Dubai Land Department (DLD) | 1.3M+ |
| + Miami, Philadelphia, Connecticut, Ireland, Taiwan | Various govt sources | 500K+ |

**Total:** 44M+ transactions.

**Access:** Free API at https://api.nwc-advisory.com/docs (Swagger UI). No login required for basic queries. Also available on RapidAPI.