### PR TITLE
Add Canada Province Energy Data to Energy section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
 Awesome Public Datasets
 =======================
-
 .. image:: https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
    :alt: Awesome
    :target: https://github.com/sindresorhus/awesome
@@ -457,7 +456,7 @@ Energy
 * |FIXME_ICON| `BLUEd - Building-Level fUlly labeled Electricity Disaggregation dataset <https://energy.duke.edu/content/building-level-fully-labeled-electricity-disaggregation-blued>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Energy/BLUEd.yml>`_]
         
 * |OK_ICON| `COMBED <http://combed.github.io/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Energy/COMBED.yml>`_]
-        
+* |OK_ICON| `Canada Province Energy Data - Province-level energy capacity, pricing, clean energy mix, and grid operators for all 10 Canadian provinces. <https://reachdata.ca/data-explorer.html>`_
 * |OK_ICON| `DBFC - Direct Borohydride Fuel Cell (DBFC) Dataset <https://github.com/ECSIM/dbfc-dataset>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Energy/DBFC.yml>`_]
         
 * |OK_ICON| `DEL - Domestic Electrical Load study datsets for South Africa (1994 - 2014) <https://www.datafirst.uct.ac.za/dataportal/index.php/catalog/DELS>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Energy/DEL.yml>`_]


### PR DESCRIPTION
Adding reachdata.ca — province-level energy data for all 10 Canadian provinces covering installed capacity (GW), clean energy percentage, average electricity price, primary energy source, and grid operator. Dataset is also published on Zenodo with DOI: https://doi.org/10.5281/zenodo.19321052
