### PR TITLE
Add Statistics of the World to Economics section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -417,7 +417,9 @@ Economics
 * |FIXME_ICON| `OpenCorporates Database of Companies in the World <https://opencorporates.com/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/OpenCorporates-Database-of-Companies-in-the-World.yml>`_]
         
 * |OK_ICON| `Our World in Data <http://ourworldindata.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/Our-World-in-Data.yml>`_]
-        
+
+* |OK_ICON| `Statistics of the World - 440+ economic, demographic, health, and environmental indicators for 218 countries with free REST API. Sources: IMF, World Bank, WHO. <https://statisticsoftheworld.com/api-docs>`_
+
 * |FIXME_ICON| `Penn World Table - PWT version 10.0 is a database with information on relative levels of [...] <https://www.rug.nl/ggdc/productivity/pwt/?lang=en/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/Penn World Table.yml>`_]
         
 * |OK_ICON| `Property Comps — Comparable Property Sales Across 11 Global Markets - Free API providing 44M+ [...] <https://api.nwc-advisory.com/docs>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/Property-Comps.yml>`_]


### PR DESCRIPTION
## What

Adding [Statistics of the World](https://statisticsoftheworld.com) to the Economics section.

## About the resource

- **440+ indicators** covering GDP, inflation, population, health, education, trade, environment, and more
- **218 countries** with historical data going back decades
- **Free REST API** — no authentication required: https://statisticsoftheworld.com/api-docs
- **Data sources**: IMF World Economic Outlook, World Bank WDI, WHO Global Health Observatory
- Compare countries, view rankings, download CSV, embed charts

This fills a gap between the raw IMF/World Bank APIs (which require multiple endpoints and different formats) and paid aggregators like Trading Economics.