### PR TITLE
Add Mindweave Synthetic SME Business Data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -369,6 +369,8 @@ Economics
 ---------
         
 * |FIXME_ICON| `AI Displacement Tracker - A structured dataset tracking 109 documented cases of AI-driven [...] <https://github.com/noahaust2/ai-displacement-tracker>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/AI-Displacement-Tracker.yml>`_]
+
+* |OK_ICON| `Mindweave Synthetic SME Business Data - 42-table synthetic business dataset with double-entry accounting, tax compliance (AU/US/UK), and temporal realism. CSV, SQL, Parquet, SQLite. <https://github.com/MindweaveTech/sme-sim-sample>`_
         
 * |OK_ICON| `Asian Productivity Organization (APO) - The AEPM provides a graphic dashboard view of [...] <https://www.apo-tokyo.org/wedo/productivity-measurement/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/APO.yml>`_]
         


### PR DESCRIPTION
## Dataset: Mindweave Synthetic SME Business Data

**URL:** https://github.com/MindweaveTech/sme-sim-sample

A 42-table synthetic business dataset generated by simulating SME operations day-by-day for 3 financial years. Features:

- **42 interconnected tables** with 44 foreign key relationships
- **Double-entry accounting** — debits always equal credits
- **Tax compliance** — Australian (ATO/GST), US (IRS/FICA), UK (HMRC/PAYE/VAT)
- **Temporal realism** — seasonal sales, staff turnover, late-paying customers
- **4 formats:** CSV, SQL (PostgreSQL), Parquet, SQLite

Free sample available on GitHub. Full datasets at https://mindweave.tech/datasets

**Section:** Economics