### PR TITLE
Add Indian government datasets: data.gov.in and RBI DBIE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -611,7 +611,9 @@ GIS
     
 Government
 ----------
-        
+* |OK_ICON| `India Government Open Data Platform (data.gov.in) <https://data.gov.in>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Government/India-data.gov.in.yaml>`_]
+
+* |OK_ICON| `Reserve Bank of India - Database on Indian Economy (DBIE) <https://dbie.rbi.org.in>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Government/India-RBI-DBIE.yaml>`_]        
 * |OK_ICON| `Alberta, Province of Canada <http://open.alberta.ca>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Government/Alberta-Province-of-Canada.yml>`_]
         
 * |FIXME_ICON| `Antwerp, Belgium <http://opendata.antwerpen.be/datasets>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Government/Antwerp-Belgium.yml>`_]


### PR DESCRIPTION
## What this PR adds

Added 2 Indian public government datasets that are widely 
used for data analysis projects in India:

- **data.gov.in** — India's official open government data 
  platform with datasets on agriculture, health, education, 
  transport, and more.

- **RBI DBIE** — Reserve Bank of India's database with 
  macroeconomic indicators, banking statistics, and 
  financial data for India.

Both datasets are free, publicly accessible, and verified.