### PR TITLE
Add S.C.A.L.A. Score (156M+ companies, 232 countries)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -434,6 +434,8 @@ Economics
         
 * |OK_ICON| `SciencesPo World Trade Gravity Datasets <http://econ.sciences-po.fr/thierry-mayer/data>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/SciencesPo-World-Trade-Gravity-Datasets.yml>`_]
         
+
+* |OK_ICON| `S.C.A.L.A. Score - Free business intelligence database with 156M+ companies across 232 countries. Search by name, VAT, or tax ID for financial data and health scoring. <https://score.get-scala.com>`_
 * |OK_ICON| `Statistics of the World — Global Economic Data for 218 Countries - 440+ economic, [...] <https://statisticsoftheworld.com/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/Statistics-of-the-World.yml>`_]
         
 * |OK_ICON| `The Atlas of Economic Complexity <http://atlas.cid.harvard.edu>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/The-Atlas-of-Economic-Complexity.yml>`_]


### PR DESCRIPTION
## What is this?

S.C.A.L.A. Score is a free, searchable business intelligence database covering 156M+ companies across 232 countries.

## Data sources

Aggregated from 40+ official government registries:
- UK Companies House, French SIRENE, German Handelsregister
- Brazilian CNPJ, Australian ABN, Japanese NTA, Russian EGRUL
- GLEIF, SEC EDGAR, OpenStreetMap, Overture Maps, Wikidata

## Access

- **Web search**: https://score.get-scala.com (no signup needed, no limits)
- **API**: https://score.get-scala.com/api/search?q=company_name
- **Scoring methodology** (open source): https://github.com/Alessandro114/company-scoring-methodology

## Why it qualifies

- Freely accessible, no signup required
- 156M+ records across 232 countries, updated regularly
- Financial data (revenue, employees) where publicly available
- Health scoring (0-100) with transparent, open-source methodology
- API available for programmatic access
- Similar to OpenCorporates (already listed) but with significantly more records and free unlimited access