### PR TITLE
Add GeneTech Knowledge Engine - 12-domain science API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,109 +51,161 @@ Architecture
         
 * |OK_ICON| `Swiss Apartment Models - This dataset contains detailed data on 42,207 apartments (242,257 [...] <https://zenodo.org/record/7070952#.Y0mACy0RqO0>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Architecture/appartment-models.yml>`_]
     
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 Biology
 -------
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `1000 Genomes - The 1000 Genomes Project ran between 2008 and 2015, creating the largest [...] <https://www.internationalgenome.org/data>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/1000-Genomes.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `ANHIR - Automatic Non-rigid Histological Image Registration (ANHIR) consists of 2D [...] <https://anhir.grand-challenge.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/ANHIR.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `American Gut (Microbiome Project) - The American Gut project is the largest crowdsourced [...] <https://github.com/biocore/American-Gut>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/American-Gut-Microbiome-Project.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `BCNB - There are WSIs of 1058 patients, part of tumor regions are annotated in WSIs. Except [...] <https://bupt-ai-cz.github.io/BCNB/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/BCNB.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Broad Bioimage Benchmark Collection (BBBC) - The Broad Bioimage Benchmark Collection (BBBC) [...] <https://www.broadinstitute.org/bbbc>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Broad-Bioimage-Benchmark-Collection-BBBC.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Broad Cancer Cell Line Encyclopedia (CCLE) <http://www.broadinstitute.org/ccle/home>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Broad-Cancer-Cell-Line-Encyclopedia-CCLE.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `CIMA: Histological Microscopy Tissue Slices - CIMA dataset includes images of 2D histological [...] <https://www.kaggle.com/datasets/jirkaborovec/histology-cima-dataset>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/CIMA.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |FIXME_ICON| `Cell Image Library <https://www.cellimagelibrary.org/home>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Cell-Image-Library.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |FIXME_ICON| `Complete Genomics Public Data - A diverse data set of whole human genomes are freely [...] <https://completegenomics.mgiamericas.com/demodata>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Complete-Genomics-Public-Data.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `CytoImageNet - A large-scale dataset of microscopy images. Contains 890,737 total grayscale [...] <https://www.kaggle.com/stanleyhua/cytoimagenet>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/CytoImageNet.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `EBI ArrayExpress - ArrayExpress Archive of Functional Genomics Data stores data from high- [...] <http://www.ebi.ac.uk/arrayexpress/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/EBI-ArrayExpress.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `EBI Protein Data Bank in Europe - The Electron Microscopy Data Bank (EMDB) is a public [...] <https://www.ebi.ac.uk/emdb/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/EBI-Protein-Data-Bank-in-Europe.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `ENCODE project - The Encyclopedia of DNA Elements (ENCODE) Consortium is an ongoing [...] <https://www.encodeproject.org>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/ENCODE-project.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Electron Microscopy Pilot Image Archive (EMPIAR) - EMPIAR, the Electron Microscopy Public [...] <http://www.ebi.ac.uk/pdbe/emdb/empiar/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Electron-Microscopy-Pilot-Image-Archive-EMPIAR.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Ensembl Genomes <https://ensemblgenomes.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Ensembl-Genomes.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Gene Expression Omnibus (GEO) - GEO is a public functional genomics data repository [...] <http://www.ncbi.nlm.nih.gov/geo/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Gene-Expression-Omnibus-GEO.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Gene Ontology (GO) - GO annotation files <http://geneontology.org/docs/download-go-annotations/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Gene-Ontology-GO.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Global Biotic Interactions (GloBI) <https://github.com/jhpoelen/eol-globi-data/wiki#accessing-species-interaction-data>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Global-Biotic-Interactions-GloBI.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Harvard Medical School (HMS) LINCS Project - The Harvard Medical School (HMS) LINCS Center is [...] <http://lincs.hms.harvard.edu>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Harvard-Medical-School-LINCS-Project.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |FIXME_ICON| `Human Genome Diversity Project - A group of scientists at Stanford University have [...] <http://www.hagsc.org/hgdp/files.html>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Human-Genome-Diversity-Project.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |FIXME_ICON| `Human Microbiome Project (HMP) - The HMP sequenced over 2000 reference genomes isolated from [...] <http://www.hmpdacc.org/reference_genomes/reference_genomes.php>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Human-Microbiome-Project-HMP.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `ICOS PSP Benchmark - The ICOS PSP benchmarks repository contains an adjustable real-world [...] <http://ico2s.org/datasets/psp_benchmark.html>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/ICOS-PSP-Benchmark.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `International HapMap Project <http://hapmap.ncbi.nlm.nih.gov/downloads/index.html.en>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/International-HapMap-Project.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Journal of Cell Biology DataViewer - All JCB data was moved to Biostudies <https://www.ebi.ac.uk/biostudies/JCB/studies>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Journal-of-Cell-Biology-DataViewer.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `KEGG - KEGG is a database resource for understanding high-level functions and utilities of [...] <http://www.genome.jp/kegg/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/KEGG.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `NCBI Proteins <http://www.ncbi.nlm.nih.gov/guide/proteins/#databases>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/NCBI-Proteins.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `NCBI Taxonomy - The NCBI Taxonomy database is a curated set of names and classifications for [...] <http://www.ncbi.nlm.nih.gov/taxonomy>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/NCBI-Taxonomy.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `NCI Genomic Data Commons - The GDC Data Portal is a robust data-driven platform that allows [...] <https://gdc.cancer.gov/access-data/gdc-data-portal>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/NCI-Genomic-Data-Commons.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `NIH Microarray data <ftp://ftp.ncbi.nih.gov/pub/geo/DATA/supplementary/series/GSE6532/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/NIH-Microarray-data.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |FIXME_ICON| `OpenSNP genotypes data - openSNP allows customers of direct-to-customer genetic tests to [...] <https://opensnp.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/OpenSNP-genotypes-data.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Palmer Penguins - The goal of palmerpenguins is to provide a great dataset for data [...] <https://allisonhorst.github.io/palmerpenguins/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Palmer-Penguins.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |FIXME_ICON| `Pathguid - Protein-Protein Interactions Catalog <http://www.pathguide.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Pathguid.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Protein Data Bank - This resource is powered by the Protein Data Bank archive-information [...] <http://www.rcsb.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Protein-Data-Bank.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Psychiatric Genomics Consortium - The purpose of the Psychiatric Genomics Consortium (PGC) is [...] <https://www.med.unc.edu/pgc/downloads>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Psychiatric-Genomics-Consortium.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `PubChem Project - PubChem is the world's largest collection of freely accessible chemical [...] <https://pubchem.ncbi.nlm.nih.gov/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/PubChem-Project.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `PubGene (now Coremine Medical) - COREMINE™ is a family of tools developed by the Norwegian [...] <https://www.coremine.com/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/PubGene-now-Coremine-Medical.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Sanger Catalogue of Somatic Mutations in Cancer (COSMIC) - COSMIC, the Catalogue Of Somatic [...] <http://cancer.sanger.ac.uk/cosmic>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Sanger-Catalogue-of-Somatic-Mutations-in-Cancer-COSMIC.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |FIXME_ICON| `Sanger Genomics of Drug Sensitivity in Cancer Project (GDSC) <http://www.cancerrxgene.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Sanger-Genomics-of-Drug-Sensitivity-in-Cancer-Project-GDSC.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Sequence Read Archive(SRA) - The Sequence Read Archive (SRA) stores raw sequence data from [...] <http://www.ncbi.nlm.nih.gov/Traces/sra/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Sequence-Read-ArchiveSRA.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Serratus - Analysis of 7.1 million RNA/DNA sequencing datasets to discover the total [...] <https://github.com/ababaian/serratus/wiki/Access-Data-Release>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Serratus-Open-Virome.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Stanford Microarray Data (Retired NOW) <http://smd.princeton.edu/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Stanford-Microarray-Data.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |FIXME_ICON| `Stowers Institute Original Data Repository <http://www.stowers.org/research/publications/odr>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Stowers-Institute-Original-Data-Repository.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Systems Science of Biological Dynamics (SSBD) Database - Systems Science of Biological [...] <http://ssbd.qbic.riken.jp>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Systems-Science-of-Biological-Dynamics-SSBD-Database.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `The Cancer Genome Atlas (TCGA), available via Broad GDAC <https://gdac.broadinstitute.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/The-Cancer-Genome-Atlas-TCGA-available-via-Broad-GDAC.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `The Catalogue of Life - The Catalogue of Life is a quality-assured checklist of more than 1.8 [...] <https://www.catalogueoflife.org/data/download>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/The-Catalogue-of-Life.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `The Personal Genome Project - The Personal Genome Project, initiated in 2005, is a vision and [...] <http://www.personalgenomes.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/The-Personal-Genome-Project.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `UCSC Public Data <http://hgdownload.soe.ucsc.edu/downloads.html>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/UCSC-Public-Data.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `UniGene <https://ftp.ncbi.nlm.nih.gov/repository/UniGene/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/UniGene.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Universal Protein Resource (UnitProt) - The Universal Protein Resource (UniProt) is a [...] <http://www.uniprot.org/downloads>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/Universal-Protein-Resource.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `iNaturalist - Community-maintained species observation database with 180M+ observations [...] <https://www.inaturalist.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/iNaturalist.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Rfam - The Rfam database is a collection of RNA families, each represented by multiple [...] <https://docs.rfam.org/en/latest/database.html>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Biology/rfam.yml>`_]
     
 Chemistry
@@ -1007,6 +1059,7 @@ Healthcare
         
 * |OK_ICON| `Yahoo Knowledge Graph COVID-19 Datasets - The Yahoo Knowledge Graph team at Verizon Media is [...] <https://github.com/yahoo/covid-19-data>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Healthcare/Yahoo-COVID-19.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |FIXME_ICON| `Informatics for Integrating Biology and the Bedside <https://www.i2b2.org/NLP/DataSets/Main.php>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Healthcare/i2b2.yml>`_]
     
 ImageProcessing
@@ -1060,6 +1113,7 @@ ImageProcessing
         
 * |OK_ICON| `KITTI Vision Benchmark Suite <http://www.cvlibs.net/datasets/kitti/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//ImageProcessing/KITTI-Vision-Benchmark-Suite.yml>`_]
         
+* |OK_ICON| `GeneTech Knowledge Engine - 12-domain knowledge base API, 4,000+ structured entities. Free REST API. <https://genetech.tools>`_
 * |OK_ICON| `Labeled Information Library of Alexandria - Biology and Conservation - Contains over 10 [...] <http://lila.science>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//ImageProcessing/LILA-BC.yml>`_]
         
 * |OK_ICON| `Long duration stitched and unstitched 8K/30 fps stereoscopic 360° videos - This 360° video [...] <https://dx.doi.org/10.21227/6htp-py25>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//ImageProcessing/Long-duration-stitched-and-unstitched-8K-30-fps-stereoscopic-360deg-videos.yml>`_]


### PR DESCRIPTION
GeneTech Knowledge Engine provides 4,000+ structured entities across 12 frontier science domains (gene technology, quantum computing, nuclear energy, brain science, etc.) via free REST API.

URL: https://genetech.tools
GitHub: https://github.com/lm203688/kb-ecosystem

Added to Biology section.