### PR TITLE
Add Texas TDLR Contractor Bond Compliance dataset (Government)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Awesome Public Datasets
+﻿Awesome Public Datasets
 =======================
 
 .. image:: https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
@@ -883,6 +883,8 @@ Government
 * |OK_ICON| `Tel-Aviv Open Data <https://opendata.tel-aviv.gov.il/en/Pages/home.aspx>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Government/Tel-Aviv.yml>`_]
         
 * |OK_ICON| `Texas Open Data <https://data.texas.gov/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Government/Texas-Open-Data.yml>`_]
+        
+* |OK_ICON| `Texas TDLR Contractor Bond Compliance - Bond status for 816,000+ Texas-licensed contractors and notaries from TDLR and Texas SOS public records. 29.3% non-compliance rate across 22 license types (Apprentice Electricians 46.9%, Tow Truck Operators 44.8%). Published by Quantum Surety Bond Watch. <https://contact219.github.io/texas-tdlr-bond-compliance-2026/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Government/Texas-TDLR-Bond-Compliance.yml>`_]
         
 * |OK_ICON| `The World Bank <https://openknowledge.worldbank.org/handle/10986/2124>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Government/The-World-Bank.yml>`_]
         


### PR DESCRIPTION
## Dataset

**Texas TDLR Contractor Bond Compliance** — Surety bond status for 816,000+ Texas-licensed contractors and notaries, sourced from TDLR (Texas Department of Licensing and Regulation) and Texas Secretary of State public records.

- **Homepage / Dataset page:** https://contact219.github.io/texas-tdlr-bond-compliance-2026/
- **Live API (free, no auth):** https://verify.quantumsurety.bond
- **Source data:** [Texas Open Data Portal — TDLR Licensees](https://data.texas.gov/dataset/TDLR-Licensees/7358-krk7)
- **Category:** Government
- **Publisher:** Quantum Surety Bond Watch
- **License:** CC0
- **Update frequency:** Monthly
- **apd-core PR:** [contact219/apd-core — Texas-TDLR-Bond-Compliance.yml](https://github.com/contact219/apd-core/tree/master/core/Government/Texas-TDLR-Bond-Compliance.yml) (pending merge to upstream)

## Why this dataset belongs here

- **Size:** 816,000+ TDLR licensing records with bond status, expiration dates, surety companies
- **Consumer relevance:** Analysis shows 29.3% of Texas licensed contractors have expired surety bonds — a significant consumer protection gap
- **22 license types covered:** Electricians (46.9% non-compliant), Tow Truck Operators (44.8%), A/C Technicians (38.9%), HVAC Contractors, Plumbers, and more
- **Public domain source:** Derived entirely from Texas Open Data Portal public records
- **API access:** Free REST API, no auth required for public endpoints

## Checklist

- [x] Data is publicly available (free, no login required)
- [x] Dataset is from a government/authoritative source (TDLR public records)
- [x] Link is live and accessible
- [x] Entry is alphabetically ordered within the Government section (between "Texas Open Data" and "The World Bank")
- [x] apd-core YAML file created in fork (metadata pending upstream PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)