### PR TITLE
Add VC Deal Flow Signal — startup engineering velocity dataset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -488,6 +488,9 @@ Economics
         
 * |OK_ICON| `Prop-Metrics — U.S. ZIP-Code-Level Real Estate Analytics Dataset - A comprehensive dataset [...] <https://www.prop-metrics.com>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Economics/prop-metrics-real-estate-data.yml>`_]
     
+        
+* |OK_ICON| `VC Deal Flow Signal - Startup Engineering Velocity — GitHub commit velocity for 324 venture-backed startups across 20 sectors. Weekly refresh. CSV, JSON, MCP server, A2A endpoint. CC BY 4.0. <https://signals.gitdealflow.com/data/startup-signals>`_ 
+
 Education
 ---------
         


### PR DESCRIPTION
## Dataset: VC Deal Flow Signal

**URL:** https://signals.gitdealflow.com/data/startup-signals

**What:** GitHub commit velocity for 324 venture-backed startups across 20 sectors. Weekly refresh since Q2 2026.

**Formats:** CSV, JSON, MCP server, A2A endpoint, OpenAPI 3.1 spec

**License:** CC BY 4.0

**Citation:** SSRN preprint 6606558 — cited on Wikipedia (Deal flow, Venture capital, GitHub pages)

**Use cases:** Venture capital deal sourcing, startup engineering analytics, academic research on open-source development velocity

**Category:** Economics (suggested)