### PR TITLE
Add NbaPropLab prop predictions track record to Sports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1837,6 +1837,8 @@ Sports
         
 * |OK_ICON| `Lahman's Baseball Database <https://sabr.org/lahman-database/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Sports/Lahmans-Baseball-Database.yml>`_]
         
+* |OK_ICON| `NbaPropLab Prop Predictions Track Record - Graded outcomes of 52,000+ NBA and WNBA player prop predictions with hit rates by tier and daily results, served as a public JSON API <https://nbaproplab.com/api/v1/track-record>`_
+
 * |OK_ICON| `NFL play-by-play data - NFL play-by-play data sourced from: [...] <https://www.dolthub.com/repositories/Liquidata/nfl-play-by-play>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Sports/NFL-play-by-play.yml>`_]
         
 * |OK_ICON| `OpenPowerlifting - Open archive of the world's powerlifting competition results — 3.9+ [...] <https://www.openpowerlifting.org/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//Sports/OpenPowerlifting.yml>`_]


### PR DESCRIPTION
Adds one dataset to the **Sports** section (alphabetical position, standard entry format):

**NbaPropLab Prop Predictions Track Record** — the graded outcomes of 52,000+ NBA and WNBA player prop predictions (hits/misses, hit rates by prediction tier, daily results series), served as a public JSON API with no key or payment required: https://nbaproplab.com/api/v1/track-record

Useful as a real-world labeled dataset for sports prediction calibration and model-evaluation work: every prediction was published before the game and settled against the actual outcome, so the labels are immune to hindsight bias.

Disclosure: the data is generated by a product I run (NbaPropLab). The endpoint listed is and will remain free and public — the dataset link is the API itself, not a marketing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
