### PR TITLE
Add Wikiprompt AI prompts dataset (MachineLearning)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1359,6 +1359,7 @@ MachineLearning
         
 * |OK_ICON| `UCI Machine Learning Repository <http://archive.ics.uci.edu/ml/>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//MachineLearning/UCI-Machine-Learning-Repository.yml>`_]
         
+* |OK_ICON| `Wikiprompt 100k AI Prompts <https://github.com/lschiaffino/wikiprompt-dataset>`_ - 100,000+ attributed AI prompts (image, video, text) with structured metadata and generated results. CC BY-SA.
 * |OK_ICON| `Yambda-5B — A Large-Scale Multi-modal Dataset for Ranking And Retrieval - Industrial-scale [...] <https://huggingface.co/datasets/yandex/yambda>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//MachineLearning/YaMBDa-5B-Music-Interaction-Dataset.yml>`_]
         
 * |FIXME_ICON| `Yahoo! Ratings and Classification Data <http://webscope.sandbox.yahoo.com/catalog.php?datatype=r>`_ [`Meta <https://github.com/awesomedata/apd-core/tree/master/core//MachineLearning/Yahoo-Ratings-and-Classification-Data.yml>`_]


### PR DESCRIPTION
Adds the Wikiprompt open dataset: 100,000+ AI prompts (image/video/text) with structured metadata, per-prompt attribution and generated results. Metadata licensed CC BY-SA; single-file dump plus docs in the linked repo.